### PR TITLE
replace poc text formatting with poc json formatting to allow submission testing

### DIFF
--- a/formatters/defaults.go
+++ b/formatters/defaults.go
@@ -1,0 +1,5 @@
+package formatters
+
+const (
+	DefaultFormat = "json"
+)

--- a/formatters/formatters.go
+++ b/formatters/formatters.go
@@ -1,0 +1,99 @@
+// Package formatters defines the abstractions used to properly format a preflight
+// Result.
+package formatters
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opdev/knex/types"
+)
+
+// Note(Jose): This is ripped from the preflight code base, but certain types have changed
+// to make this work here. E.g. types.Results vs. certification.Resutls.
+
+// ResponseFormatter describes the expected methods a formatter
+// must implement.
+type ResponseFormatter interface {
+	// PrettyName is the name used to represent this formatter.
+	PrettyName() string
+	// FileExtension represents the file extension one might use when creating
+	// a file with the contents of this formatter.
+	FileExtension() string
+	// Format takes Results, formats it as needed, and returns the formatted
+	// results ready to write as a byte slice.
+	Format(context.Context, types.Results) (response []byte, formattingError error)
+}
+
+// // NewForConfig returns a new formatter based on the user-provided configuration. It relies
+// // on config values which should align with known/supported/built-in formatters.
+// func NewForConfig(cfg config.Config) (ResponseFormatter, error) {
+// 	return NewByName(cfg.ResponseFormat())
+// }
+
+// NewByName returns a predefined ResponseFormatter with the given name.
+// TODO: New* funcs in this package may benefit from renaming.
+func NewByName(name string) (ResponseFormatter, error) {
+	formatter, defined := availableFormatters[name]
+	if !defined {
+		return nil, fmt.Errorf("%s: %s",
+			"The requested formatter is unknown",
+			name,
+		)
+	}
+
+	return formatter, nil
+}
+
+// note(jose): This is also ripped from the preflight libs but this, I believe, was a public facing type
+// and the rest was not.
+type FormatterFunc = func(context.Context, types.Results) (response []byte, formattingError error)
+
+// New returns a new formatter with the provided name and FormatterFunc.
+func New(name, extension string, fn FormatterFunc) (ResponseFormatter, error) {
+	if len(name) == 0 {
+		return nil, fmt.Errorf(
+			"failed to create a new generic formatter: formatter name is required",
+		)
+	}
+
+	gf := genericFormatter{
+		name:          name,
+		formatterFunc: fn,
+		fileExtension: extension,
+	}
+
+	return &gf, nil
+}
+
+// genericFormatter represents a generic approach to formatting that implements the
+// ResponseFormatter interface. Can be leveraged to build a custom formatter quickly.
+type genericFormatter struct {
+	name          string
+	fileExtension string
+	formatterFunc FormatterFunc
+}
+
+// Name returns a string identification of the formatter that's in use.
+func (f *genericFormatter) PrettyName() string {
+	return f.name
+}
+
+// Format returns the formatted results as a byte slice.
+func (f *genericFormatter) Format(ctx context.Context, r types.Results) ([]byte, error) {
+	return f.formatterFunc(ctx, r)
+}
+
+// FileExtension returns the extension a user might use when formatting
+// results with this formatter and writing that to disk.
+func (f *genericFormatter) FileExtension() string {
+	return f.fileExtension
+}
+
+// availableFormatters maps configuration-friendly values to pretty representations
+// of the same value, and their corresponding Formatter included with this library.
+var availableFormatters = map[string]ResponseFormatter{
+	"json":     &genericFormatter{"Generic JSON", "json", genericJSONFormatter},
+	"xml":      &genericFormatter{"Generic XML", "xml", genericXMLFormatter},
+	"junitxml": &genericFormatter{"JUnit XML", "xml", junitXMLFormatter},
+}

--- a/formatters/formatters_suite_test.go
+++ b/formatters/formatters_suite_test.go
@@ -1,0 +1,13 @@
+package formatters
+
+// import (
+// 	"testing"
+
+// 	. "github.com/onsi/ginkgo/v2"
+// 	. "github.com/onsi/gomega"
+// )
+
+// func TestFormatters(t *testing.T) {
+// 	RegisterFailHandler(Fail)
+// 	RunSpecs(t, "Formatters Suite")
+// }

--- a/formatters/formatters_test.go
+++ b/formatters/formatters_test.go
@@ -1,0 +1,90 @@
+package formatters
+
+// import (
+// 	"context"
+// 	"fmt"
+
+// 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+// 	"github.com/redhat-openshift-ecosystem/openshift-preflight/formatters"
+// 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
+
+// 	. "github.com/onsi/ginkgo/v2"
+// 	. "github.com/onsi/gomega"
+// )
+
+// var _ = Describe("Formatters", func() {
+// 	Describe("When getting the formatter for the named default format", func() {
+// 		It("should never fail", func() {
+// 			_, err := NewByName(DefaultFormat)
+// 			Expect(err).ToNot(HaveOccurred())
+// 		})
+// 	})
+// 	Describe("When getting a new formatter for a configuration", func() {
+// 		Context("with a valid configuration", func() {
+// 			cfg := runtime.Config{
+// 				ResponseFormat: "json",
+// 			}
+
+// 			It("should return a formatter and no error", func() {
+// 				formatter, err := NewForConfig(cfg.ReadOnly())
+// 				Expect(err).ToNot(HaveOccurred())
+// 				Expect(formatter).ToNot(BeNil())
+// 			})
+// 		})
+
+// 		Context("with an unknown format requested by the user", func() {
+// 			cfg := runtime.Config{
+// 				ResponseFormat: "unknownFormat",
+// 			}
+
+// 			It("should return an error", func() {
+// 				formatter, err := NewForConfig(cfg.ReadOnly())
+
+// 				Expect(err).To(HaveOccurred())
+// 				Expect(formatter).To(BeNil())
+// 			})
+// 		})
+// 	})
+
+// 	Describe("When creating a new generic formatter", func() {
+// 		Context("with improper arguments", func() {
+// 			expectedResult := []byte(fmt.Errorf("failed to create a new generic formatter: formatter name is required").Error())
+// 			var fn formatters.FormatterFunc //nolint:gosimple // We want to be explicit here for clarity
+// 			fn = func(context.Context, certification.Results) ([]byte, error) {
+// 				return expectedResult, nil
+// 			}
+
+// 			emptyNameFormatter, err := New("", "txt", fn)
+// 			It("should return an error because of an empty name", func() {
+// 				Expect(err).To(HaveOccurred())
+// 				Expect(emptyNameFormatter).To(BeNil())
+// 			})
+// 		})
+
+// 		Context("with proper arguments", func() {
+// 			expectedResult := []byte("this is a test")
+// 			name := "testFormatter"
+// 			extension := "txt"
+// 			var fn formatters.FormatterFunc //nolint:gosimple // We want to be explicit here for clarity
+// 			fn = func(context.Context, certification.Results) ([]byte, error) {
+// 				return expectedResult, nil
+// 			}
+
+// 			formatter, err := New(name, extension, fn)
+// 			It("should not return an error", func() {
+// 				Expect(err).ToNot(HaveOccurred())
+// 				Expect(formatter).ToNot(BeNil())
+// 			})
+
+// 			formattingResult, err := formatter.Format(context.TODO(), certification.Results{})
+// 			It("should format results as expected", func() {
+// 				Expect(err).ToNot(HaveOccurred())
+// 				Expect(formattingResult).To(Equal(expectedResult))
+// 			})
+
+// 			It("should be identifiable as the provided name", func() {
+// 				Expect(formatter.PrettyName()).To(Equal(name))
+// 			})
+// 		})
+// 	})
+// })

--- a/formatters/generic.go
+++ b/formatters/generic.go
@@ -1,0 +1,49 @@
+package formatters
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+
+	"github.com/opdev/knex/types"
+)
+
+var (
+	jsonMarshalIndent = json.MarshalIndent
+	xmlMarshalIndent  = xml.MarshalIndent
+)
+
+// genericJSONFormatter is a FormatterFunc that formats results as JSON
+func genericJSONFormatter(ctx context.Context, r types.Results) ([]byte, error) {
+	response := getResponse(r)
+
+	responseJSON, err := jsonMarshalIndent(response, "", "    ")
+	if err != nil {
+		e := fmt.Errorf("error formatting results with formatter %s: %w",
+			"json",
+			err,
+		)
+
+		return nil, e
+	}
+
+	return responseJSON, nil
+}
+
+// genericXMLFormatter is a FormatterFunc that formats results as XML
+func genericXMLFormatter(ctx context.Context, r types.Results) ([]byte, error) {
+	response := getResponse(r)
+
+	responseXML, err := xmlMarshalIndent(response, "", "    ")
+	if err != nil {
+		e := fmt.Errorf("error formatting results with formatter %s: %w",
+			"xml",
+			err,
+		)
+
+		return nil, e
+	}
+
+	return responseXML, nil
+}

--- a/formatters/generic_test.go
+++ b/formatters/generic_test.go
@@ -1,0 +1,168 @@
+package formatters
+
+// import (
+// 	"context"
+// 	"encoding/json"
+// 	"encoding/xml"
+// 	"errors"
+// 	"strings"
+// 	"testing"
+// 	"time"
+
+// 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+// 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
+
+// 	"gotest.tools/v3/assert"
+// )
+
+// func TestGenericJSONFormatter(t *testing.T) {
+// 	generateTestResults := func(image string, passed bool) certification.Results {
+// 		return certification.Results{
+// 			TestedImage:   image,
+// 			PassedOverall: passed,
+// 			Passed: []certification.Result{
+// 				{
+// 					Check:       check.NewGenericCheck("passed1", nil, check.Metadata{}, check.HelpText{}),
+// 					ElapsedTime: 1000 * time.Millisecond,
+// 				},
+// 			},
+// 			Failed: []certification.Result{
+// 				{
+// 					Check:       check.NewGenericCheck("failed1", nil, check.Metadata{}, check.HelpText{}),
+// 					ElapsedTime: 1001 * time.Millisecond,
+// 				},
+// 			},
+// 		}
+// 	}
+
+// 	testCases := []struct {
+// 		results              certification.Results
+// 		marshalIndentFailure bool
+// 		expectedErrString    string
+// 	}{
+// 		{
+// 			results:              generateTestResults("image1", true),
+// 			marshalIndentFailure: false,
+// 		},
+// 		{
+// 			results:              generateTestResults("image2", false),
+// 			marshalIndentFailure: false,
+// 		},
+// 		{
+// 			results:              generateTestResults("image3", true),
+// 			marshalIndentFailure: true, // failure to json.MarshalIndent
+// 			expectedErrString:    "this is an error",
+// 		},
+// 	}
+
+// 	for _, tc := range testCases {
+// 		// Patch the function if we expect an error
+// 		if tc.marshalIndentFailure {
+// 			jsonMarshalIndent = func(v interface{}, prefix, indent string) ([]byte, error) {
+// 				return nil, errors.New("this is an error")
+// 			}
+// 		} else {
+// 			jsonMarshalIndent = json.MarshalIndent
+// 		}
+
+// 		// Run the function
+// 		funcOutput, err := genericJSONFormatter(context.TODO(), tc.results)
+
+// 		if err == nil {
+// 			// Marshal the response JSON back into an object
+// 			var testResponseObj UserResponse
+// 			assert.NilError(t, json.Unmarshal(funcOutput, &testResponseObj))
+
+// 			// Assertions
+// 			assert.Equal(t, tc.results.TestedImage, testResponseObj.Image)
+// 			assert.Equal(t, tc.results.PassedOverall, testResponseObj.Passed)
+
+// 			for index, i := range tc.results.Passed {
+// 				assert.Equal(t, i.Name(), testResponseObj.Results.Passed[index].Name)
+// 				assert.Equal(t, float64(i.ElapsedTime/time.Millisecond), testResponseObj.Results.Passed[index].ElapsedTime)
+// 			}
+// 			for index, i := range tc.results.Failed {
+// 				assert.Equal(t, i.Name(), testResponseObj.Results.Failed[index].Name)
+// 				assert.Equal(t, float64(i.ElapsedTime/time.Millisecond), testResponseObj.Results.Failed[index].ElapsedTime)
+// 			}
+// 		} else {
+// 			assert.Equal(t, true, strings.Contains(err.Error(), tc.expectedErrString))
+// 		}
+// 	}
+// }
+
+// func TestGenericXMLFormatter(t *testing.T) {
+// 	generateTestResults := func(image string, passed bool) certification.Results {
+// 		return certification.Results{
+// 			TestedImage:   image,
+// 			PassedOverall: passed,
+// 			Passed: []certification.Result{
+// 				{
+// 					Check:       check.NewGenericCheck("passed1", nil, check.Metadata{}, check.HelpText{}),
+// 					ElapsedTime: 1000 * time.Millisecond,
+// 				},
+// 			},
+// 			Failed: []certification.Result{
+// 				{
+// 					Check:       check.NewGenericCheck("failed1", nil, check.Metadata{}, check.HelpText{}),
+// 					ElapsedTime: 1001 * time.Millisecond,
+// 				},
+// 			},
+// 		}
+// 	}
+
+// 	testCases := []struct {
+// 		results              certification.Results
+// 		marshalIndentFailure bool
+// 		expectedErrString    string
+// 	}{
+// 		{
+// 			results:              generateTestResults("image1", true),
+// 			marshalIndentFailure: false,
+// 		},
+// 		{
+// 			results:              generateTestResults("image2", false),
+// 			marshalIndentFailure: false,
+// 		},
+// 		{
+// 			results:              generateTestResults("image3", true),
+// 			marshalIndentFailure: true, // failure to xml.MarshalIndent
+// 			expectedErrString:    "this is an error",
+// 		},
+// 	}
+
+// 	for _, tc := range testCases {
+// 		// Patch the function if we expect an error
+// 		if tc.marshalIndentFailure {
+// 			xmlMarshalIndent = func(v interface{}, prefix, indent string) ([]byte, error) {
+// 				return nil, errors.New("this is an error")
+// 			}
+// 		} else {
+// 			xmlMarshalIndent = xml.MarshalIndent
+// 		}
+
+// 		// Run the function
+// 		funcOutput, err := genericXMLFormatter(context.TODO(), tc.results)
+
+// 		if err == nil {
+// 			// Marshal the response XML back into an object
+// 			var testResponseObj UserResponse
+// 			assert.NilError(t, xml.Unmarshal(funcOutput, &testResponseObj))
+
+// 			// Assertions
+// 			assert.Equal(t, tc.results.TestedImage, testResponseObj.Image)
+// 			assert.Equal(t, tc.results.PassedOverall, testResponseObj.Passed)
+
+// 			for index, i := range tc.results.Passed {
+// 				assert.Equal(t, i.Name(), testResponseObj.Results.Passed[index].Name)
+// 				assert.Equal(t, float64(i.ElapsedTime/time.Millisecond), testResponseObj.Results.Passed[index].ElapsedTime)
+// 			}
+// 			for index, i := range tc.results.Failed {
+// 				assert.Equal(t, i.Name(), testResponseObj.Results.Failed[index].Name)
+// 				assert.Equal(t, float64(i.ElapsedTime/time.Millisecond), testResponseObj.Results.Failed[index].ElapsedTime)
+// 			}
+// 		} else {
+// 			assert.Equal(t, true, strings.Contains(err.Error(), tc.expectedErrString))
+// 		}
+// 	}
+// }

--- a/formatters/junitxml.go
+++ b/formatters/junitxml.go
@@ -1,0 +1,107 @@
+package formatters
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"time"
+
+	"github.com/opdev/knex/types"
+)
+
+type JUnitTestSuites struct {
+	XMLName xml.Name         `xml:"testsuites"`
+	Suites  []JUnitTestSuite `xml:"testsuite"`
+}
+
+type JUnitTestSuite struct {
+	XMLName    xml.Name        `xml:"testsuite"`
+	Tests      int             `xml:"tests,attr"`
+	Failures   int             `xml:"failures,attr"`
+	Time       string          `xml:"time,attr"`
+	Name       string          `xml:"name,attr"`
+	Properties []JUnitProperty `xml:"properties>property,omitempty"`
+	TestCases  []JUnitTestCase `xml:"testcase"`
+}
+
+type JUnitTestCase struct {
+	XMLName     xml.Name          `xml:"testcase"`
+	Classname   string            `xml:"classname,attr"`
+	Name        string            `xml:"name,attr"`
+	Time        string            `xml:"time,attr"`
+	SkipMessage *JUnitSkipMessage `xml:"skipped,omitempty"`
+	Failure     *JUnitFailure     `xml:"failure,omitempty"`
+	SystemOut   string            `xml:"system-out,omitempty"`
+	Message     string            `xml:",chardata"`
+}
+
+type JUnitSkipMessage struct {
+	Message string `xml:"message,attr"`
+}
+
+type JUnitProperty struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+type JUnitFailure struct {
+	Message  string `xml:"message,attr"`
+	Type     string `xml:"type,attr"`
+	Contents string `xml:",chardata"`
+}
+
+func junitXMLFormatter(ctx context.Context, r types.Results) ([]byte, error) {
+	response := getResponse(r)
+	suites := JUnitTestSuites{}
+	testsuite := JUnitTestSuite{
+		Tests:      len(r.Errors) + len(r.Failed) + len(r.Passed),
+		Failures:   len(r.Errors) + len(r.Failed),
+		Time:       "0s",
+		Name:       "Red Hat Certification",
+		Properties: []JUnitProperty{},
+		TestCases:  []JUnitTestCase{},
+	}
+
+	totalDuration := time.Duration(0)
+	for _, result := range r.Passed {
+		testCase := JUnitTestCase{
+			Classname: response.Image,
+			Name:      result.Name(),
+			Time:      fmt.Sprintf("%f", result.ElapsedTime.Seconds()),
+			Failure:   nil,
+			Message:   result.Metadata().Description,
+		}
+		testsuite.TestCases = append(testsuite.TestCases, testCase)
+		totalDuration += result.ElapsedTime
+	}
+
+	for _, result := range append(r.Errors, r.Failed...) {
+		testCase := JUnitTestCase{
+			Classname: response.Image,
+			Name:      result.Name(),
+			Time:      result.ElapsedTime.String(),
+			Failure: &JUnitFailure{
+				Message:  "Failed",
+				Type:     "",
+				Contents: fmt.Sprintf("%s: Suggested Fix: %s", result.Help().Message, result.Help().Suggestion),
+			},
+		}
+		testsuite.TestCases = append(testsuite.TestCases, testCase)
+		totalDuration += result.ElapsedTime
+	}
+
+	testsuite.Time = fmt.Sprintf("%f", totalDuration.Seconds())
+	suites.Suites = append(suites.Suites, testsuite)
+
+	bytes, err := xml.MarshalIndent(suites, "", "\t")
+	if err != nil {
+		o := fmt.Errorf("error formatting results with formatter %s: %v",
+			"junitxml",
+			err,
+		)
+
+		return nil, o
+	}
+
+	return bytes, nil
+}

--- a/formatters/junitxml_test.go
+++ b/formatters/junitxml_test.go
@@ -1,0 +1,91 @@
+package formatters
+
+// import (
+// 	"context"
+// 	"errors"
+
+// 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+// 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
+// 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
+// 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
+
+// 	. "github.com/onsi/ginkgo/v2"
+// 	. "github.com/onsi/gomega"
+// )
+
+// var _ = Describe("JUnitXML Formatter", func() {
+// 	Context("With a valid UserResponse", func() {
+// 		var response certification.Results
+// 		BeforeEach(func() {
+// 			response = certification.Results{
+// 				TestedImage:   "example.com/repo/image:tag",
+// 				PassedOverall: true,
+// 				TestedOn: runtime.OpenshiftClusterVersion{
+// 					Name:    "ClusterName",
+// 					Version: "Clusterversion",
+// 				},
+// 				CertificationHash: "",
+// 				Passed: []certification.Result{
+// 					{
+// 						Check: check.NewGenericCheck(
+// 							"PassedCheck",
+// 							func(ctx context.Context, ir image.ImageReference) (bool, error) { return true, nil },
+// 							check.Metadata{
+// 								Description:      "description",
+// 								KnowledgeBaseURL: "kburl",
+// 								CheckURL:         "checkurl",
+// 							},
+// 							check.HelpText{
+// 								Message:    "helptext",
+// 								Suggestion: "suggestion",
+// 							}),
+// 						ElapsedTime: 0,
+// 					},
+// 				},
+// 				Failed: []certification.Result{
+// 					{
+// 						Check: check.NewGenericCheck(
+// 							"FailedCheck",
+// 							func(ctx context.Context, ir image.ImageReference) (bool, error) { return false, nil },
+// 							check.Metadata{
+// 								Description:      "description",
+// 								KnowledgeBaseURL: "kburl",
+// 								CheckURL:         "checkurl",
+// 							},
+// 							check.HelpText{
+// 								Message:    "helptext",
+// 								Suggestion: "suggestion",
+// 							}),
+// 						ElapsedTime: 0,
+// 					},
+// 				},
+// 				Errors: []certification.Result{
+// 					{
+// 						Check: check.NewGenericCheck(
+// 							"ErroredCheck",
+// 							func(ctx context.Context, ir image.ImageReference) (bool, error) {
+// 								return false, errors.New("someerror")
+// 							},
+// 							check.Metadata{
+// 								Description:      "description",
+// 								KnowledgeBaseURL: "kburl",
+// 								CheckURL:         "checkurl",
+// 							},
+// 							check.HelpText{
+// 								Message:    "helptext",
+// 								Suggestion: "suggestion",
+// 							}),
+// 						ElapsedTime: 0,
+// 					},
+// 				},
+// 			}
+// 		})
+// 		It("should format without error", func() {
+// 			out, err := junitXMLFormatter(context.TODO(), response)
+// 			Expect(err).ToNot(HaveOccurred())
+// 			Expect(string(out)).To(ContainSubstring("PassedCheck"))
+// 			Expect(string(out)).To(ContainSubstring("FailedCheck"))
+// 			Expect(string(out)).To(ContainSubstring("ErroredCheck"))
+// 		})
+// 	})
+// })

--- a/formatters/util.go
+++ b/formatters/util.go
@@ -1,0 +1,91 @@
+package formatters
+
+import (
+	"github.com/opdev/knex/types"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
+)
+
+// getResponse will extract the runtime's results and format it to fit the
+// UserResponse definition in a way that can then be formatted.
+func getResponse(r types.Results) UserResponse {
+	passedChecks := make([]checkExecutionInfo, 0, len(r.Passed))
+	failedChecks := make([]checkExecutionInfo, 0, len(r.Failed))
+	erroredChecks := make([]checkExecutionInfo, 0, len(r.Errors))
+
+	if len(r.Passed) > 0 {
+		for _, check := range r.Passed {
+			passedChecks = append(passedChecks, checkExecutionInfo{
+				Name:        check.Name(),
+				ElapsedTime: float64(check.ElapsedTime.Milliseconds()),
+				Description: check.Metadata().Description,
+			})
+		}
+	}
+
+	if len(r.Failed) > 0 {
+		for _, check := range r.Failed {
+			failedChecks = append(failedChecks, checkExecutionInfo{
+				Name:             check.Name(),
+				ElapsedTime:      float64(check.ElapsedTime.Milliseconds()),
+				Description:      check.Metadata().Description,
+				Help:             check.Help().Message,
+				Suggestion:       check.Help().Suggestion,
+				KnowledgeBaseURL: check.Metadata().KnowledgeBaseURL,
+				CheckURL:         check.Metadata().CheckURL,
+			})
+		}
+	}
+
+	if len(r.Errors) > 0 {
+		for _, check := range r.Errors {
+			erroredChecks = append(erroredChecks, checkExecutionInfo{
+				Name:        check.Name(),
+				ElapsedTime: float64(check.ElapsedTime.Milliseconds()),
+				Description: check.Metadata().Description,
+				Help:        check.Help().Message,
+			})
+		}
+	}
+
+	response := UserResponse{
+		Image:             r.TestedImage,
+		Passed:            r.PassedOverall,
+		LibraryInfo:       version.Version,
+		CertificationHash: r.CertificationHash,
+		Results: resultsText{
+			Passed: passedChecks,
+			Failed: failedChecks,
+			Errors: erroredChecks,
+		},
+	}
+
+	return response
+}
+
+// UserResponse is the standard user-facing response.
+type UserResponse struct {
+	Image             string                 `json:"image" xml:"image"`
+	Passed            bool                   `json:"passed" xml:"passed"`
+	CertificationHash string                 `json:"certification_hash,omitempty" xml:"certification_hash,omitempty"`
+	LibraryInfo       version.VersionContext `json:"test_library" xml:"test_library"`
+	Results           resultsText            `json:"results" xml:"results"`
+}
+
+// resultsText represents the results of check execution against the asset.
+type resultsText struct {
+	Passed []checkExecutionInfo `json:"passed" xml:"passed"`
+	Failed []checkExecutionInfo `json:"failed" xml:"failed"`
+	Errors []checkExecutionInfo `json:"errors" xml:"errors"`
+}
+
+// checkExecutionInfo contains all possible output fields that a user might see in their result.
+// Empty fields will be omitted.
+type checkExecutionInfo struct {
+	Name             string  `json:"name,omitempty" xml:"name,omitempty"`
+	ElapsedTime      float64 `json:"elapsed_time" xml:"elapsed_time"`
+	Description      string  `json:"description,omitempty" xml:"description,omitempty"`
+	Help             string  `json:"help,omitempty" xml:"help,omitempty"`
+	Suggestion       string  `json:"suggestion,omitempty" xml:"suggestion,omitempty"`
+	KnowledgeBaseURL string  `json:"knowledgebase_url,omitempty" xml:"knowledgebase_url,omitempty"`
+	CheckURL         string  `json:"check_url,omitempty" xml:"check_url,omitempty"`
+}


### PR DESCRIPTION
In order for container-cert to test submission, we need to write to JSON. I haven't wired up the formatters formally, but as a PoC, I've replaced the Text Formatter with a json formatter.