### PR TITLE
Remove context from command constructor signature

### DIFF
--- a/cmd/knex/listplugins/listplugins.go
+++ b/cmd/knex/listplugins/listplugins.go
@@ -1,16 +1,13 @@
 package listplugins
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/opdev/knex/plugin/v0"
 	"github.com/spf13/cobra"
 )
 
-func NewCommand(
-	ctx context.Context,
-) *cobra.Command {
+func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list-plugins",
 		Short: "list the plugins that have been registered",

--- a/cmd/knex/main.go
+++ b/cmd/knex/main.go
@@ -8,11 +8,10 @@ import (
 )
 
 func main() {
-	entrypoint := root.NewCommand(
-		context.Background(),
-	)
+	entrypoint := root.NewCommand()
 
-	if err := entrypoint.Execute(); err != nil {
+	ctx := context.Background()
+	if err := entrypoint.ExecuteContext(ctx); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/knex/root/root.go
+++ b/cmd/knex/root/root.go
@@ -2,7 +2,6 @@
 package root
 
 import (
-	"context"
 
 	// register all plugins
 	_ "github.com/opdev/knex/plugin/registration"
@@ -13,19 +12,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewCommand(
-	ctx context.Context,
-) *cobra.Command {
+func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "knex",
 		Short: "Pluggable Certification",
 	}
 
-	cmd.AddCommand(listplugins.NewCommand(ctx))
-	cmd.AddCommand(run.NewCommand(ctx))
-	cmd.AddCommand(version.NewCommand(ctx))
-	cmd.AddCommand(run.NewBackwardsCompatCheckCommand(ctx))
-
+	cmd.AddCommand(listplugins.NewCommand())
+	cmd.AddCommand(run.NewCommand())
+	cmd.AddCommand(version.NewCommand())
+	cmd.AddCommand(run.NewBackwardsCompatCheckCommand())
 	return cmd
 }
 

--- a/cmd/knex/run/compat-commands.go
+++ b/cmd/knex/run/compat-commands.go
@@ -1,8 +1,6 @@
 package run
 
 import (
-	"context"
-
 	"github.com/opdev/knex/plugin/v0"
 	"github.com/opdev/knex/types"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
@@ -16,7 +14,7 @@ import (
 // `preflight check` command, but will run the corresponding plugins instead. It
 // is expected that this subcommand will be removed near-future after this
 // redesign is published.
-func NewBackwardsCompatCheckCommand(ctx context.Context) *cobra.Command {
+func NewBackwardsCompatCheckCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "check",
 		Short: "Run checks for an operator or container. This is subcommand exists for backwards compatibility and will be removed in a future release.",
@@ -40,19 +38,19 @@ func NewBackwardsCompatCheckCommand(ctx context.Context) *cobra.Command {
 	containerConfig.SetDefault("submit", false)
 
 	// Build out the Container Plugin
-	cmd.AddCommand(containerPlugin(ctx, containerConfig))
+	cmd.AddCommand(containerPlugin(containerConfig))
 	// cmd.Hidden = true
 	return cmd
 }
 
 // containerPlugin explicitly calls the check-container plugin. This should only
 // be used for backwards compatibility purposes.
-func containerPlugin(ctx context.Context, config *viper.Viper) *cobra.Command {
+func containerPlugin(config *viper.Viper) *cobra.Command {
 	// TODO(Jose): This is hard coded to depend on the name of the container check to be check-container
 	plug := plugin.RegisteredPlugins()["check-container"]
-	plcmd := plugin.NewCommand(ctx, config, "check-container", plug)
+	plcmd := plugin.NewCommand(config, "check-container", plug)
 	plcmd.RunE = func(cmd *cobra.Command, args []string) error {
-		return run(ctx, args, "check-container", config, &types.ResultWriterFile{})
+		return run(cmd.Context(), args, "check-container", config, &types.ResultWriterFile{})
 	}
 	plcmd.Use = "container"
 	return plcmd

--- a/cmd/knex/run/run.go
+++ b/cmd/knex/run/run.go
@@ -22,9 +22,7 @@ const (
 	DefaultLogLevel = "info"
 )
 
-func NewCommand(
-	ctx context.Context,
-) *cobra.Command {
+func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run a Certification Plugin.",
@@ -39,9 +37,9 @@ func NewCommand(
 		invocation := i
 		plug := p
 		config := spfviper.New()
-		plcmd := plugin.NewCommand(ctx, config, invocation, plug)
+		plcmd := plugin.NewCommand(config, invocation, plug)
 		plcmd.RunE = func(cmd *cobra.Command, args []string) error {
-			return run(ctx, args, invocation, config, &types.ResultWriterFile{})
+			return run(cmd.Context(), args, invocation, config, &types.ResultWriterFile{})
 		}
 
 		// Configure the parent command's config bindings after the plugin has bound its flagset.

--- a/cmd/knex/version/version.go
+++ b/cmd/knex/version/version.go
@@ -1,7 +1,6 @@
 package version
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,7 +11,7 @@ import (
 
 const flagAsJSON = "as-json"
 
-func NewCommand(ctx context.Context) *cobra.Command {
+func NewCommand() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "version",
 		Short: "Version information for this tool.",
@@ -26,7 +25,6 @@ func NewCommand(ctx context.Context) *cobra.Command {
 		},
 	}
 
-	cmd.SetContext(ctx)
 	cmd.Flags().Bool(flagAsJSON, false, "Returns version metadata as a JSON blob")
 	return &cmd
 }

--- a/plugin/v0/command.go
+++ b/plugin/v0/command.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -9,7 +8,6 @@ import (
 )
 
 func NewCommand(
-	ctx context.Context,
 	config *viper.Viper,
 	invocation string,
 	pl Plugin,


### PR DESCRIPTION
The context for commands can be gotten from Cobra itself, set by the parent. Context does not need to be injected to each constructor directly.